### PR TITLE
Fixed crash when hitting Blitz's Q

### DIFF
--- a/Champions/Blitzcrank/Q.cs
+++ b/Champions/Blitzcrank/Q.cs
@@ -36,11 +36,15 @@ namespace Spells
             var damage = 25 + spell.Level * 55 + ap;
             target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL,
                 false);
-            ApiFunctionManager.LogInfo("Before if " + target);
             if (!target.IsDead)
             {
                 ApiFunctionManager.AddParticleTarget(owner, "Blitzcrank_Grapplin_tar.troy", target, 1, "L_HAND");
-                target.setPosition(owner.X, owner.Y);
+                var current = new Vector2(owner.X, owner.Y);
+                var to = Vector2.Normalize(new Vector2(spell.X, spell.Y) - current);
+                var range = to * 50;
+                var trueCoords = current + range;
+                ApiFunctionManager.DashToLocation((ObjAIBase)target, trueCoords.X, trueCoords.Y,
+                    spell.SpellData.MissileSpeed, true);
             }
 
             projectile.setToRemove();

--- a/Champions/Blitzcrank/Q.cs
+++ b/Champions/Blitzcrank/Q.cs
@@ -34,17 +34,13 @@ namespace Spells
         {
             var ap = owner.GetStats().AbilityPower.Total;
             var damage = 25 + spell.Level * 55 + ap;
-            spell.Target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL,
+            target.TakeDamage(owner, damage, DamageType.DAMAGE_TYPE_MAGICAL, DamageSource.DAMAGE_SOURCE_SPELL,
                 false);
-            if (!spell.Target.IsDead)
+            ApiFunctionManager.LogInfo("Before if " + target);
+            if (!target.IsDead)
             {
-                ApiFunctionManager.AddParticleTarget(owner, "Blitzcrank_Grapplin_tar.troy", spell.Target, 1, "L_HAND");
-                var current = new Vector2(owner.X, owner.Y);
-                var to = Vector2.Normalize(new Vector2(spell.X, spell.Y) - current);
-                var range = to * 50;
-                var trueCoords = current + range;
-                ApiFunctionManager.DashToLocation((ObjAIBase) spell.Target, trueCoords.X, trueCoords.Y,
-                    spell.SpellData.MissileSpeed, true);
+                ApiFunctionManager.AddParticleTarget(owner, "Blitzcrank_Grapplin_tar.troy", target, 1, "L_HAND");
+                target.setPosition(owner.X, owner.Y);
             }
 
             projectile.setToRemove();


### PR DESCRIPTION
No longer crash the server when hitting something with Blitz's Grab. The target is teleported on Blitz. However, the target doesn't appear on him if it doesn't do any action like moving casting spell, ect...